### PR TITLE
Added tests for config.go and changed dynamodb tests to use type assertion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Code in this repo requires code owners to review all pull requests
 
-* @mshort55
+*       @mshort55

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Good dynamodb commands:
     - check all active prayers have active intercessors (this would only be needed to recover from inconsistent states; possible low priority)
     - send out prayer reminder texts to intercessors after x number of hours with unprayed prayer requests
         - also consider copying prayer to another intercessor if it has not been prayed for in x number of hours
-- long tests utilizing real ddb, lambda, sns, and sim phone numbers
+- tests utilizing real ddb, lambda, sns, and sim phone numbers
     - implement simulator numbers with sns topics
     - implement secure way to save authentication
 - rename state tracker to fault tracker - is tracking error states the only thing necessary? is there any benefit to track completed requests?
@@ -65,7 +65,6 @@ Good dynamodb commands:
 - pass down lambda handler context to lower aws service functions so that context can be re-used
     - this will follow go best practices and allow for better aws debugging (xray tracing)
 - save all initial sign up text messages for 10-DLC number requirements
-- unit tests for config
 - web frontend for sign up process
     - possibly could add other features eventually
     - minimum required feature is to be able to complete entire sign up flow in a web form and submit to be added to prayer texter app

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,17 +1,75 @@
 package config_test
 
 import (
-	"fmt"
+	"os"
 	"testing"
 
 	"github.com/4JesusApps/prayertexter/internal/config"
+	"github.com/4JesusApps/prayertexter/internal/db"
+	"github.com/4JesusApps/prayertexter/internal/messaging"
+	"github.com/4JesusApps/prayertexter/internal/object"
+	"github.com/4JesusApps/prayertexter/internal/utility"
 	"github.com/spf13/viper"
 )
 
-func TestDefaults(t *testing.T) {
+func TestDefaultConfigValues(t *testing.T) {
 	t.Run("verify that all default config values get passed through viper as expected", func(t *testing.T) {
 		config.InitConfig()
 
-		fmt.Println(viper.GetInt("conf.aws.db.timeout"))
+		configs := map[string]any{
+			utility.AwsSvcMaxBackoffConfigPath:      utility.DefaultAwsSvcMaxBackoff,
+			utility.AwsSvcRetryAttemptsConfigPath:   utility.DefaultAwsSvcRetryAttempts,
+			db.TimeoutConfigPath:                    db.DefaultTimeout,
+			object.IntercessorPhonesTableConfigPath: object.DefaultIntercessorPhonesTable,
+			object.MemberTableConfigPath:            object.DefaultMemberTable,
+			object.ActivePrayersTableConfigPath:     object.DefaultActivePrayersTable,
+			object.QueuedPrayersTableConfigPath:     object.DefaultQueuedPrayersTable,
+			object.StateTrackerTableConfigPath:      object.DefaultStateTrackerTable,
+			messaging.PhoneConfigPath:               messaging.DefaultPhone,
+			messaging.TimeoutConfigPath:             messaging.DefaultTimeout,
+			object.IntercessorsPerPrayerConfigPath:  object.DefaultIntercessorsPerPrayer,
+		}
+
+		var config any
+		for configPath, configValue := range configs {
+			switch configValue.(type) {
+			case int:
+				config = viper.GetInt(configPath)
+			case string:
+				config = viper.GetString(configPath)
+			default:
+				t.Errorf("expected type int or string, got %T", configValue)
+				return
+			}
+
+			if config != configValue {
+				t.Errorf("expected value for config path %v to be %v, got %v", configPath, configValue, config)
+			}
+		}
+	})
+}
+
+func TestEnvironmentalVariableOverride(t *testing.T) {
+	t.Run("verify environmental variables can override default config values", func(t *testing.T) {
+		config.InitConfig()
+		defaultPhone := viper.GetString(messaging.PhoneConfigPath)
+		newPhone := "+17777777777"
+
+		err := os.Setenv("PRAY_CONF_AWS_SMS_PHONE", newPhone)
+		if err != nil {
+			t.Errorf("unexpected error when setting environmental variable, %v", err)
+			return
+		}
+
+		config.InitConfig()
+		phone := viper.GetString(messaging.PhoneConfigPath)
+
+		if phone == defaultPhone {
+			t.Errorf("expected phones to not be equal, got %v for both", phone)
+		}
+
+		if phone != newPhone {
+			t.Errorf("expected phone to be %v, got %v", newPhone, phone)
+		}
 	})
 }

--- a/internal/db/dynamodb.go
+++ b/internal/db/dynamodb.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	DefaultTimeout          = 60
-	timeoutConfigPath = "conf.aws.db.timeout"
+	TimeoutConfigPath = "conf.aws.db.timeout"
 )
 
 type DDBConnecter interface {
@@ -50,7 +50,7 @@ func GetDdbClient() (*dynamodb.Client, error) {
 }
 
 func getDdbItem(ddbClnt DDBConnecter, attr, key, table string) (*dynamodb.GetItemOutput, error) {
-	timeout := viper.GetInt(timeoutConfigPath)
+	timeout := viper.GetInt(TimeoutConfigPath)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 
@@ -77,7 +77,7 @@ func GetDdbObject[T any](ddbClnt DDBConnecter, attr, key, table string) (*T, err
 }
 
 func putDdbItem(ddbClnt DDBConnecter, table string, data map[string]types.AttributeValue) error {
-	timeout := viper.GetInt(timeoutConfigPath)
+	timeout := viper.GetInt(TimeoutConfigPath)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 
@@ -103,7 +103,7 @@ func PutDdbObject[T any](ddbClnt DDBConnecter, table string, object *T) error {
 }
 
 func DelDdbItem(ddbClnt DDBConnecter, attr, key, table string) error {
-	timeout := viper.GetInt(timeoutConfigPath)
+	timeout := viper.GetInt(TimeoutConfigPath)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 

--- a/internal/db/dynamodb_test.go
+++ b/internal/db/dynamodb_test.go
@@ -199,25 +199,21 @@ func TestDynamoDBOperations(t *testing.T) {
 		},
 	}
 
-	testedObjectTypes := []string{"Member", "IntercessorPhones", "Prayer", "StateTracker"}
-
-	t.Run("Test GetDdbObject", func(t *testing.T) {
+	t.Run("GetDdbObject", func(t *testing.T) {
 		ddbMock := &mock.DDBConnecter{}
 		ddbMock.GetItemResults = expectedDdbItems
 
-		for index, objectType := range testedObjectTypes {
-			t.Run(fmt.Sprintf("Get %s", objectType), func(t *testing.T) {
-				obj := expectedObjects[index]
-
-				switch objectType {
-				case "Member":
-					testGetObject(t, ddbMock, obj.(*object.Member))
-				case "IntercessorPhones":
-					testGetObject(t, ddbMock, obj.(*object.IntercessorPhones))
-				case "Prayer":
-					testGetObject(t, ddbMock, obj.(*object.Prayer))
-				case "StateTracker":
-					testGetObject(t, ddbMock, obj.(*object.StateTracker))
+		for _, obj := range expectedObjects {
+			t.Run(fmt.Sprintf("Get %T", obj), func(t *testing.T) {
+				switch o := obj.(type) {
+				case *object.Member:
+					testGetObject(t, ddbMock, o)
+				case *object.IntercessorPhones:
+					testGetObject(t, ddbMock, o)
+				case *object.Prayer:
+					testGetObject(t, ddbMock, o)
+				case *object.StateTracker:
+					testGetObject(t, ddbMock, o)
 				default:
 					t.Errorf("unexpected object type %T", obj)
 				}
@@ -225,22 +221,20 @@ func TestDynamoDBOperations(t *testing.T) {
 		}
 	})
 
-	t.Run("Test PutDdbObject", func(t *testing.T) {
+	t.Run("PutDdbObject", func(t *testing.T) {
 		ddbMock := &mock.DDBConnecter{}
 
-		for index, objectType := range testedObjectTypes {
-			t.Run(fmt.Sprintf("Put %s", objectType), func(t *testing.T) {
-				obj := expectedObjects[index]
-
-				switch objectType {
-				case "Member":
-					testPutObject(t, ddbMock, obj.(*object.Member), expectedDdbItems[index])
-				case "IntercessorPhones":
-					testPutObject(t, ddbMock, obj.(*object.IntercessorPhones), expectedDdbItems[index])
-				case "Prayer":
-					testPutObject(t, ddbMock, obj.(*object.Prayer), expectedDdbItems[index])
-				case "StateTracker":
-					testPutObject(t, ddbMock, obj.(*object.StateTracker), expectedDdbItems[index])
+		for index, obj := range expectedObjects {
+			t.Run(fmt.Sprintf("Put %T", obj), func(t *testing.T) {
+				switch o := obj.(type) {
+				case *object.Member:
+					testPutObject(t, ddbMock, o, expectedDdbItems[index])
+				case *object.IntercessorPhones:
+					testPutObject(t, ddbMock, o, expectedDdbItems[index])
+				case *object.Prayer:
+					testPutObject(t, ddbMock, o, expectedDdbItems[index])
+				case *object.StateTracker:
+					testPutObject(t, ddbMock, o, expectedDdbItems[index])
 				default:
 					t.Errorf("unexpected object type %T", obj)
 				}

--- a/internal/messaging/textmessage.go
+++ b/internal/messaging/textmessage.go
@@ -16,10 +16,10 @@ import (
 
 const (
 	DefaultPhone    = "+12762908579"
-	phoneConfigPath = "conf.aws.sms.phone"
+	PhoneConfigPath = "conf.aws.sms.phone"
 
 	DefaultTimeout    = 60
-	timeoutConfigPath = "conf.aws.sms.timeout"
+	TimeoutConfigPath = "conf.aws.sms.timeout"
 
 	// Sign up messages.
 	MsgNameRequest       = "Reply your name, or 2 to stay anonymous"
@@ -84,12 +84,12 @@ func SendText(smsClnt TextSender, msg TextMessage) error {
 	// This helps with SAM local testing. We don't want to actually send a SMS when doing SAM local tests (for now).
 	// However when unit testing, we can't skip this part since this is mocked and receives inputs.
 	if !utility.IsAwsLocal() {
-		timeout := viper.GetInt(timeoutConfigPath)
+		timeout := viper.GetInt(TimeoutConfigPath)
 		ctx, cancel := context.WithTimeout(context.Background(),
 			time.Duration(timeout)*time.Second)
 		defer cancel()
 
-		phone := viper.GetString(phoneConfigPath)
+		phone := viper.GetString(PhoneConfigPath)
 		input := &pinpointsmsvoicev2.SendTextMessageInput{
 			DestinationPhoneNumber: aws.String(msg.Phone),
 			MessageBody:            aws.String(body),

--- a/internal/object/intercessorphones.go
+++ b/internal/object/intercessorphones.go
@@ -17,14 +17,14 @@ type IntercessorPhones struct {
 
 const (
 	DefaultIntercessorPhonesTable    = "General"
-	intercessorPhonesTableConfigPath = "conf.aws.db.intercessorphones.table"
+	IntercessorPhonesTableConfigPath = "conf.aws.db.intercessorphones.table"
 
 	IntercessorPhonesAttribute = "Key"
 	IntercessorPhonesKey       = "IntercessorPhones"
 )
 
 func (i *IntercessorPhones) Get(ddbClnt db.DDBConnecter) error {
-	table := viper.GetString(intercessorPhonesTableConfigPath)
+	table := viper.GetString(IntercessorPhonesTableConfigPath)
 	intr, err := db.GetDdbObject[IntercessorPhones](ddbClnt, IntercessorPhonesAttribute, IntercessorPhonesKey, table)
 
 	if err != nil {
@@ -41,7 +41,7 @@ func (i *IntercessorPhones) Get(ddbClnt db.DDBConnecter) error {
 }
 
 func (i *IntercessorPhones) Put(ddbClnt db.DDBConnecter) error {
-	table := viper.GetString(intercessorPhonesTableConfigPath)
+	table := viper.GetString(IntercessorPhonesTableConfigPath)
 	i.Key = IntercessorPhonesKey
 
 	return db.PutDdbObject(ddbClnt, table, i)

--- a/internal/object/member.go
+++ b/internal/object/member.go
@@ -20,7 +20,7 @@ type Member struct {
 
 const (
 	DefaultMemberTable    = "Members"
-	memberTableConfigPath = "conf.aws.db.member.table"
+	MemberTableConfigPath = "conf.aws.db.member.table"
 	
 	MemberAttribute       = "Phone"
 
@@ -34,7 +34,7 @@ const (
 )
 
 func (m *Member) Get(ddbClnt db.DDBConnecter) error {
-	table := viper.GetString(memberTableConfigPath)
+	table := viper.GetString(MemberTableConfigPath)
 	mem, err := db.GetDdbObject[Member](ddbClnt, MemberAttribute, m.Phone, table)
 	if err != nil {
 		return err
@@ -50,12 +50,12 @@ func (m *Member) Get(ddbClnt db.DDBConnecter) error {
 }
 
 func (m *Member) Put(ddbClnt db.DDBConnecter) error {
-	table := viper.GetString(memberTableConfigPath)
+	table := viper.GetString(MemberTableConfigPath)
 	return db.PutDdbObject(ddbClnt, table, m)
 }
 
 func (m *Member) Delete(ddbClnt db.DDBConnecter) error {
-	table := viper.GetString(memberTableConfigPath)
+	table := viper.GetString(MemberTableConfigPath)
 	return db.DelDdbItem(ddbClnt, MemberAttribute, m.Phone, table)
 }
 

--- a/internal/object/prayer.go
+++ b/internal/object/prayer.go
@@ -15,10 +15,10 @@ type Prayer struct {
 
 const (
 	DefaultActivePrayersTable    = "ActivePrayers"
-	activePrayersTableConfigPath = "conf.aws.db.prayer.activetable"
+	ActivePrayersTableConfigPath = "conf.aws.db.prayer.activetable"
 
 	DefaultQueuedPrayersTable    = "QueuedPrayers"
-	queuedPrayersTableConfigPath = "conf.aws.db.prayer.queuetable"
+	QueuedPrayersTableConfigPath = "conf.aws.db.prayer.queuetable"
 
 	DefaultIntercessorsPerPrayer    = 2
 	IntercessorsPerPrayerConfigPath = "conf.intercessorsperprayer"
@@ -58,8 +58,8 @@ func (p *Prayer) Delete(ddbClnt db.DDBConnecter, queue bool) error {
 }
 
 func GetPrayerTable(queue bool) string {
-	queuedPrayersTable := viper.GetString(queuedPrayersTableConfigPath)
-	activePrayersTable := viper.GetString(activePrayersTableConfigPath)
+	queuedPrayersTable := viper.GetString(QueuedPrayersTableConfigPath)
+	activePrayersTable := viper.GetString(ActivePrayersTableConfigPath)
 
 	if queue {
 		return queuedPrayersTable

--- a/internal/object/statetracker.go
+++ b/internal/object/statetracker.go
@@ -23,7 +23,7 @@ type State struct {
 
 const (
 	DefaultStateTrackerTable    = "General"
-	stateTrackerTableConfigPath = "conf.aws.db.statetracker.table"
+	StateTrackerTableConfigPath = "conf.aws.db.statetracker.table"
 
 	StateTrackerAttribute = "Key"
 	StateTrackerKey       = "StateTracker"
@@ -33,7 +33,7 @@ const (
 )
 
 func (st *StateTracker) Get(ddbClnt db.DDBConnecter) error {
-	table := viper.GetString(stateTrackerTableConfigPath)
+	table := viper.GetString(StateTrackerTableConfigPath)
 	sttrackr, err := db.GetDdbObject[StateTracker](ddbClnt, StateTrackerAttribute, StateTrackerKey, table)
 	if err != nil {
 		return err
@@ -49,7 +49,7 @@ func (st *StateTracker) Get(ddbClnt db.DDBConnecter) error {
 }
 
 func (st *StateTracker) Put(ddbClnt db.DDBConnecter) error {
-	table := viper.GetString(stateTrackerTableConfigPath)
+	table := viper.GetString(StateTrackerTableConfigPath)
 	st.Key = StateTrackerKey
 
 	return db.PutDdbObject(ddbClnt, string(table), st)

--- a/internal/utility/aws.go
+++ b/internal/utility/aws.go
@@ -13,15 +13,15 @@ import (
 
 const (
 	DefaultAwsSvcRetryAttempts    = 5
-	awsSvcRetryAttemptsConfigPath = "conf.aws.retry"
+	AwsSvcRetryAttemptsConfigPath = "conf.aws.retry"
 
 	DefaultAwsSvcMaxBackoff    = 10
-	awsSvcMaxBackoffConfigPath = "conf.aws.backoff"
+	AwsSvcMaxBackoffConfigPath = "conf.aws.backoff"
 )
 
 func GetAwsConfig() (aws.Config, error) {
-	maxRetry := viper.GetInt(awsSvcRetryAttemptsConfigPath)
-	maxBackoff := viper.GetInt(awsSvcMaxBackoffConfigPath)
+	maxRetry := viper.GetInt(AwsSvcRetryAttemptsConfigPath)
+	maxBackoff := viper.GetInt(AwsSvcMaxBackoffConfigPath)
 
 	cfg, err := config.LoadDefaultConfig(
 		context.TODO(),


### PR DESCRIPTION
I added tests for the config package. The main goals were to ensure that viper passes the default config values as expected. This ensures that the viper implementation is working, as well as the added bonus of double checking that all value paths to default values are correct. I also tested the feature of being able to override default values by setting a new value in an environmental variable, which was the whole point of setting up viper in the first place. Lastly, I updated dynamodb tests to use type assertion to clean up the code a bit.
