### PR TITLE
Passed down context to all aws functions, rearranged dymnamodb and sms client parameters to improve organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Good dynamodb commands:
 - implement text/template for message content
 - add tests for aws retry mechanism - is it worth it?
 - add logging for aws retry operations - is it worth it?
-- pass down lambda handler context to lower aws service functions so that context can be re-used
-    - this will follow go best practices and allow for better aws debugging (xray tracing)
 - save all initial sign up text messages for 10-DLC number requirements
 - web frontend for sign up process
     - possibly could add other features eventually

--- a/cmd/prayertexter/main.go
+++ b/cmd/prayertexter/main.go
@@ -6,11 +6,11 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/4JesusApps/prayertexter/internal/db"
 	"github.com/4JesusApps/prayertexter/internal/messaging"
 	"github.com/4JesusApps/prayertexter/internal/prayertexter"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
 )
 
 // MUST BE SET by go build -ldflags "-X main.version=999"
@@ -39,7 +39,7 @@ func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.API
 		return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 	}
 
-	if err := prayertexter.MainFlow(msg, ddbClnt, smsClnt); err != nil {
+	if err := prayertexter.MainFlow(ctx, ddbClnt, smsClnt, msg); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,5 +52,4 @@ func InitConfig() {
 	viper.SetEnvPrefix("pray")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
-
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/4JesusApps/prayertexter/internal/config"
@@ -55,11 +54,7 @@ func TestEnvironmentalVariableOverride(t *testing.T) {
 		defaultPhone := viper.GetString(messaging.PhoneConfigPath)
 		newPhone := "+17777777777"
 
-		err := os.Setenv("PRAY_CONF_AWS_SMS_PHONE", newPhone)
-		if err != nil {
-			t.Errorf("unexpected error when setting environmental variable, %v", err)
-			return
-		}
+		t.Setenv("PRAY_CONF_AWS_SMS_PHONE", newPhone)
 
 		config.InitConfig()
 		phone := viper.GetString(messaging.PhoneConfigPath)

--- a/internal/db/dynamodb_test.go
+++ b/internal/db/dynamodb_test.go
@@ -1,18 +1,19 @@
 package db_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/4JesusApps/prayertexter/internal/db"
 	"github.com/4JesusApps/prayertexter/internal/messaging"
 	"github.com/4JesusApps/prayertexter/internal/mock"
 	"github.com/4JesusApps/prayertexter/internal/object"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 func TestDynamoDBOperations(t *testing.T) {
@@ -244,8 +245,9 @@ func TestDynamoDBOperations(t *testing.T) {
 }
 
 func testGetObject[T any](t *testing.T, ddbMock db.DDBConnecter, expectedObject *T) {
+	ctx := context.Background()
 	// The parameters test test test are used here because mocking makes using real parameters unnecessary.
-	testedObject, err := db.GetDdbObject[T](ddbMock, "test", "test", "test")
+	testedObject, err := db.GetDdbObject[T](ctx, ddbMock, "test", "test", "test")
 	if err != nil {
 		t.Errorf("getDdbObject failed for type %T: %v", expectedObject, err)
 	}
@@ -260,8 +262,9 @@ func testPutObject[T any](t *testing.T, ddbMock *mock.DDBConnecter, expectedObje
 	Output *dynamodb.GetItemOutput
 	Error  error
 }) {
+	ctx := context.Background()
 	// The parameter test is used here because mocking makes using real parameters unnecessary.
-	err := db.PutDdbObject(ddbMock, "test", expectedObject)
+	err := db.PutDdbObject(ctx, ddbMock, "test", expectedObject)
 	if err != nil {
 		t.Errorf("putDdbObject failed for type %T: %v", expectedObject, err)
 	}

--- a/internal/messaging/textmessage.go
+++ b/internal/messaging/textmessage.go
@@ -6,11 +6,11 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/4JesusApps/prayertexter/internal/utility"
 	goaway "github.com/TwiN/go-away"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2"
 	"github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2/types"
-	"github.com/4JesusApps/prayertexter/internal/utility"
 	"github.com/spf13/viper"
 )
 
@@ -78,15 +78,14 @@ func GetSmsClient() (*pinpointsmsvoicev2.Client, error) {
 	return smsClnt, nil
 }
 
-func SendText(smsClnt TextSender, msg TextMessage) error {
+func SendText(ctx context.Context, smsClnt TextSender, msg TextMessage) error {
 	body := MsgPre + msg.Body + "\n\n" + MsgPost
 
 	// This helps with SAM local testing. We don't want to actually send a SMS when doing SAM local tests (for now).
 	// However when unit testing, we can't skip this part since this is mocked and receives inputs.
 	if !utility.IsAwsLocal() {
 		timeout := viper.GetInt(TimeoutConfigPath)
-		ctx, cancel := context.WithTimeout(context.Background(),
-			time.Duration(timeout)*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 		defer cancel()
 
 		phone := viper.GetString(PhoneConfigPath)

--- a/internal/messaging/textmessage_test.go
+++ b/internal/messaging/textmessage_test.go
@@ -1,6 +1,7 @@
 package messaging_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/4JesusApps/prayertexter/internal/config"
@@ -16,8 +17,9 @@ func TestSendText(t *testing.T) {
 			Phone: "+11234567890",
 		}
 		txtMock := &mock.TextSender{}
+		ctx := context.Background()
 
-		if err := messaging.SendText(txtMock, msg); err != nil {
+		if err := messaging.SendText(ctx, txtMock, msg); err != nil {
 			t.Errorf("unexpected error, %v", err)
 		}
 

--- a/internal/object/intercessorphones.go
+++ b/internal/object/intercessorphones.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"log/slog"
 	"math/rand/v2"
 	"slices"
@@ -23,9 +24,10 @@ const (
 	IntercessorPhonesKey       = "IntercessorPhones"
 )
 
-func (i *IntercessorPhones) Get(ddbClnt db.DDBConnecter) error {
+func (i *IntercessorPhones) Get(ctx context.Context, ddbClnt db.DDBConnecter) error {
 	table := viper.GetString(IntercessorPhonesTableConfigPath)
-	intr, err := db.GetDdbObject[IntercessorPhones](ddbClnt, IntercessorPhonesAttribute, IntercessorPhonesKey, table)
+	intr, err := db.GetDdbObject[IntercessorPhones](ctx, ddbClnt, IntercessorPhonesAttribute, IntercessorPhonesKey,
+		table)
 
 	if err != nil {
 		return err
@@ -40,11 +42,11 @@ func (i *IntercessorPhones) Get(ddbClnt db.DDBConnecter) error {
 	return nil
 }
 
-func (i *IntercessorPhones) Put(ddbClnt db.DDBConnecter) error {
+func (i *IntercessorPhones) Put(ctx context.Context, ddbClnt db.DDBConnecter) error {
 	table := viper.GetString(IntercessorPhonesTableConfigPath)
 	i.Key = IntercessorPhonesKey
 
-	return db.PutDdbObject(ddbClnt, table, i)
+	return db.PutDdbObject(ctx, ddbClnt, table, i)
 }
 
 func (i *IntercessorPhones) AddPhone(phone string) {

--- a/internal/object/member_test.go
+++ b/internal/object/member_test.go
@@ -1,16 +1,17 @@
 package object_test
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strconv"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/4JesusApps/prayertexter/internal/messaging"
 	"github.com/4JesusApps/prayertexter/internal/mock"
 	"github.com/4JesusApps/prayertexter/internal/object"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 func TestSendMessage(t *testing.T) {
@@ -30,7 +31,8 @@ func TestSendMessage(t *testing.T) {
 		}
 
 		txtMock := &mock.TextSender{}
-		if err := member.SendMessage(txtMock, txtBody); err != nil {
+		ctx := context.Background()
+		if err := member.SendMessage(ctx, txtMock, txtBody); err != nil {
 			t.Errorf("unexpected error %v", err)
 		}
 
@@ -75,9 +77,10 @@ func TestIsMemberActive(t *testing.T) {
 
 	ddbMock := &mock.DDBConnecter{}
 	ddbMock.GetItemResults = mockGetItemResults
+	ctx := context.Background()
 
 	t.Run("Member is not active", func(t *testing.T) {
-		isActive, err := object.IsMemberActive(ddbMock, "+11234567890")
+		isActive, err := object.IsMemberActive(ctx, ddbMock, "+11234567890")
 		if err != nil {
 			t.Errorf("unexpected error %v", err)
 		} else if isActive {
@@ -86,7 +89,7 @@ func TestIsMemberActive(t *testing.T) {
 	})
 
 	t.Run("Member is active", func(t *testing.T) {
-		isActive, err := object.IsMemberActive(ddbMock, "+11234567890")
+		isActive, err := object.IsMemberActive(ctx, ddbMock, "+11234567890")
 		if err != nil {
 			t.Errorf("unexpected error %v", err)
 		} else if !isActive {
@@ -94,7 +97,7 @@ func TestIsMemberActive(t *testing.T) {
 		}
 	})
 	t.Run("returns error on get Member dynamodb call", func(t *testing.T) {
-		_, err := object.IsMemberActive(ddbMock, "+11234567890")
+		_, err := object.IsMemberActive(ctx, ddbMock, "+11234567890")
 		if err == nil {
 			t.Errorf("expected error, got %v", err)
 		}

--- a/internal/object/prayer.go
+++ b/internal/object/prayer.go
@@ -1,6 +1,8 @@
 package object
 
 import (
+	"context"
+
 	"github.com/4JesusApps/prayertexter/internal/db"
 	"github.com/4JesusApps/prayertexter/internal/utility"
 	"github.com/spf13/viper"
@@ -26,10 +28,10 @@ const (
 	PrayersAttribute = "IntercessorPhone"
 )
 
-func (p *Prayer) Get(ddbClnt db.DDBConnecter, queue bool) error {
+func (p *Prayer) Get(ctx context.Context, ddbClnt db.DDBConnecter, queue bool) error {
 	// Queue determines whether ActivePrayers or PrayersQueue table is used for dynamodb get requests.
 	table := GetPrayerTable(queue)
-	pryr, err := db.GetDdbObject[Prayer](ddbClnt, PrayersAttribute, p.IntercessorPhone, table)
+	pryr, err := db.GetDdbObject[Prayer](ctx, ddbClnt, PrayersAttribute, p.IntercessorPhone, table)
 	if err != nil {
 		return err
 	}
@@ -43,18 +45,18 @@ func (p *Prayer) Get(ddbClnt db.DDBConnecter, queue bool) error {
 	return nil
 }
 
-func (p *Prayer) Put(ddbClnt db.DDBConnecter, queue bool) error {
+func (p *Prayer) Put(ctx context.Context, ddbClnt db.DDBConnecter, queue bool) error {
 	// Prayers get queued in order to save them for a time when intercessors are available. This will change the
 	// dynamodb table that the prayer is saved to.
 	table := GetPrayerTable(queue)
 
-	return db.PutDdbObject(ddbClnt, table, p)
+	return db.PutDdbObject(ctx, ddbClnt, table, p)
 }
 
-func (p *Prayer) Delete(ddbClnt db.DDBConnecter, queue bool) error {
+func (p *Prayer) Delete(ctx context.Context, ddbClnt db.DDBConnecter, queue bool) error {
 	table := GetPrayerTable(queue)
 
-	return db.DelDdbItem(ddbClnt, PrayersAttribute, p.IntercessorPhone, table)
+	return db.DelDdbItem(ctx, ddbClnt, PrayersAttribute, p.IntercessorPhone, table)
 }
 
 func GetPrayerTable(queue bool) string {
@@ -68,9 +70,9 @@ func GetPrayerTable(queue bool) string {
 	}
 }
 
-func IsPrayerActive(ddbClnt db.DDBConnecter, phone string) (bool, error) {
+func IsPrayerActive(ctx context.Context, ddbClnt db.DDBConnecter, phone string) (bool, error) {
 	pryr := Prayer{IntercessorPhone: phone}
-	if err := pryr.Get(ddbClnt, false); err != nil {
+	if err := pryr.Get(ctx, ddbClnt, false); err != nil {
 		return false, utility.WrapError(err, "failed to check if Prayer is active")
 	}
 

--- a/internal/object/prayer_test.go
+++ b/internal/object/prayer_test.go
@@ -1,15 +1,16 @@
 package object_test
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/4JesusApps/prayertexter/internal/config"
 	"github.com/4JesusApps/prayertexter/internal/mock"
 	"github.com/4JesusApps/prayertexter/internal/object"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 func TestGetPrayerTable(t *testing.T) {
@@ -80,9 +81,10 @@ func TestCheckIfActivePrayer(t *testing.T) {
 
 	ddbMock := &mock.DDBConnecter{}
 	ddbMock.GetItemResults = mockGetItemResults
+	ctx := context.Background()
 
 	t.Run("Prayer is not active", func(t *testing.T) {
-		isActive, err := object.IsPrayerActive(ddbMock, "+11111111111")
+		isActive, err := object.IsPrayerActive(ctx, ddbMock, "+11111111111")
 		if err != nil {
 			t.Errorf("unexpected error %v", err)
 		} else if isActive {
@@ -91,7 +93,7 @@ func TestCheckIfActivePrayer(t *testing.T) {
 	})
 
 	t.Run("Prayer is active", func(t *testing.T) {
-		isActive, err := object.IsPrayerActive(ddbMock, "+11111111111")
+		isActive, err := object.IsPrayerActive(ctx, ddbMock, "+11111111111")
 		if err != nil {
 			t.Errorf("unexpected error %v", err)
 		} else if !isActive {
@@ -100,7 +102,7 @@ func TestCheckIfActivePrayer(t *testing.T) {
 	})
 
 	t.Run("returns error on get Prayer dynamodb call", func(t *testing.T) {
-		_, err := object.IsPrayerActive(ddbMock, "+11111111111")
+		_, err := object.IsPrayerActive(ctx, ddbMock, "+11111111111")
 		if err == nil {
 			t.Errorf("expected error, got %v", err)
 		}

--- a/internal/object/statetracker.go
+++ b/internal/object/statetracker.go
@@ -1,6 +1,8 @@
 package object
 
 import (
+	"context"
+
 	"github.com/4JesusApps/prayertexter/internal/db"
 	"github.com/4JesusApps/prayertexter/internal/messaging"
 	"github.com/4JesusApps/prayertexter/internal/utility"
@@ -32,9 +34,9 @@ const (
 	StateFailed     = "FAILED"
 )
 
-func (st *StateTracker) Get(ddbClnt db.DDBConnecter) error {
+func (st *StateTracker) Get(ctx context.Context, ddbClnt db.DDBConnecter) error {
 	table := viper.GetString(StateTrackerTableConfigPath)
-	sttrackr, err := db.GetDdbObject[StateTracker](ddbClnt, StateTrackerAttribute, StateTrackerKey, table)
+	sttrackr, err := db.GetDdbObject[StateTracker](ctx, ddbClnt, StateTrackerAttribute, StateTrackerKey, table)
 	if err != nil {
 		return err
 	}
@@ -48,16 +50,16 @@ func (st *StateTracker) Get(ddbClnt db.DDBConnecter) error {
 	return nil
 }
 
-func (st *StateTracker) Put(ddbClnt db.DDBConnecter) error {
+func (st *StateTracker) Put(ctx context.Context, ddbClnt db.DDBConnecter) error {
 	table := viper.GetString(StateTrackerTableConfigPath)
 	st.Key = StateTrackerKey
 
-	return db.PutDdbObject(ddbClnt, string(table), st)
+	return db.PutDdbObject(ctx, ddbClnt, table, st)
 }
 
-func (s *State) Update(ddbClnt db.DDBConnecter, remove bool) error {
+func (s *State) Update(ctx context.Context, ddbClnt db.DDBConnecter, remove bool) error {
 	st := StateTracker{}
-	if err := st.Get(ddbClnt); err != nil {
+	if err := st.Get(ctx, ddbClnt); err != nil {
 		return utility.WrapError(err, "failed state update")
 	}
 
@@ -72,7 +74,7 @@ func (s *State) Update(ddbClnt db.DDBConnecter, remove bool) error {
 		st.States = append(st.States, *s)
 	}
 
-	err := st.Put(ddbClnt)
+	err := st.Put(ctx, ddbClnt)
 
 	return utility.WrapError(err, "failed state update")
 }

--- a/internal/object/statetracker_test.go
+++ b/internal/object/statetracker_test.go
@@ -1,15 +1,16 @@
 package object_test
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/4JesusApps/prayertexter/internal/messaging"
 	"github.com/4JesusApps/prayertexter/internal/mock"
 	"github.com/4JesusApps/prayertexter/internal/object"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 func TestUpdate(t *testing.T) {
@@ -88,9 +89,10 @@ func TestUpdate(t *testing.T) {
 
 	ddbMock := &mock.DDBConnecter{}
 	ddbMock.GetItemResults = mockGetItemResults
+	ctx := context.Background()
 
 	t.Run("add new State to StateTracker", func(t *testing.T) {
-		if err := newState.Update(ddbMock, false); err != nil {
+		if err := newState.Update(ctx, ddbMock, false); err != nil {
 			t.Errorf("unexpected error %v", err)
 		}
 		input := ddbMock.PutItemInputs[0]
@@ -100,7 +102,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("removes new State to StateTracker", func(t *testing.T) {
 		// this resets the GetItem mock so that it can re-use mockGetItemResults
 		ddbMock.GetItemCalls = 0
-		if err := newState.Update(ddbMock, true); err != nil {
+		if err := newState.Update(ctx, ddbMock, true); err != nil {
 			t.Errorf("unexpected error %v", err)
 		}
 

--- a/internal/prayertexter/prayertexter_test.go
+++ b/internal/prayertexter/prayertexter_test.go
@@ -1,6 +1,7 @@
 package prayertexter_test
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strconv"
@@ -8,15 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/4JesusApps/prayertexter/internal/messaging"
 	"github.com/4JesusApps/prayertexter/internal/mock"
 	"github.com/4JesusApps/prayertexter/internal/object"
 	"github.com/4JesusApps/prayertexter/internal/prayertexter"
 	"github.com/4JesusApps/prayertexter/internal/utility"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 type TestCase struct {
@@ -734,19 +735,20 @@ func TestMainFlowSignUp(t *testing.T) {
 	for _, test := range testCases {
 		txtMock := &mock.TextSender{}
 		ddbMock := &mock.DDBConnecter{}
+		ctx := context.Background()
 
 		t.Run(test.description, func(t *testing.T) {
 			setMocks(ddbMock, txtMock, test)
 
 			if test.expectedError {
 				// Handles failures for error mocks.
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err == nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err == nil {
 					t.Fatalf("expected error, got nil")
 				}
 				testNumMethodCalls(ddbMock, txtMock, t, test)
 			} else {
 				// Handles success test cases.
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err != nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err != nil {
 					t.Fatalf("unexpected error starting MainFlow: %v", err)
 				}
 
@@ -860,11 +862,12 @@ func TestMainFlowSignUpWrongInputs(t *testing.T) {
 	for _, test := range testCases {
 		txtMock := &mock.TextSender{}
 		ddbMock := &mock.DDBConnecter{}
+		ctx := context.Background()
 
 		t.Run(test.description, func(t *testing.T) {
 			setMocks(ddbMock, txtMock, test)
 
-			if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err != nil {
+			if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err != nil {
 				t.Fatalf("unexpected error starting MainFlow: %v", err)
 			}
 
@@ -1224,19 +1227,20 @@ func TestMainFlowMemberDelete(t *testing.T) {
 	for _, test := range testCases {
 		txtMock := &mock.TextSender{}
 		ddbMock := &mock.DDBConnecter{}
+		ctx := context.Background()
 
 		t.Run(test.description, func(t *testing.T) {
 			setMocks(ddbMock, txtMock, test)
 
 			if test.expectedError {
 				// Handles failures for error mocks.
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err == nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err == nil {
 					t.Fatalf("expected error, got nil")
 				}
 				testNumMethodCalls(ddbMock, txtMock, t, test)
 			} else {
 				// Handles success test cases.
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err != nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err != nil {
 					t.Fatalf("unexpected error starting MainFlow: %v", err)
 				}
 
@@ -1339,11 +1343,12 @@ func TestMainFlowHelp(t *testing.T) {
 	for _, test := range testCases {
 		txtMock := &mock.TextSender{}
 		ddbMock := &mock.DDBConnecter{}
+		ctx := context.Background()
 
 		t.Run(test.description, func(t *testing.T) {
 			setMocks(ddbMock, txtMock, test)
 
-			if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err != nil {
+			if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err != nil {
 				t.Fatalf("unexpected error starting MainFlow: %v", err)
 			}
 
@@ -1792,19 +1797,20 @@ func TestMainFlowPrayerRequest(t *testing.T) {
 	for _, test := range testCases {
 		txtMock := &mock.TextSender{}
 		ddbMock := &mock.DDBConnecter{}
+		ctx := context.Background()
 
 		t.Run(test.description, func(t *testing.T) {
 			setMocks(ddbMock, txtMock, test)
 
 			if test.expectedError {
 				// handles failures for error mocks
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err == nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err == nil {
 					t.Fatalf("expected error, got nil")
 				}
 				testNumMethodCalls(ddbMock, txtMock, t, test)
 			} else {
 				// handles success test cases
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err != nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err != nil {
 					t.Fatalf("unexpected error starting MainFlow: %v", err)
 				}
 
@@ -2350,19 +2356,20 @@ func TestFindIntercessors(t *testing.T) {
 	for _, test := range testCases {
 		txtMock := &mock.TextSender{}
 		ddbMock := &mock.DDBConnecter{}
+		ctx := context.Background()
 
 		t.Run(test.description, func(t *testing.T) {
 			setMocks(ddbMock, txtMock, test)
 
 			if test.expectedError {
 				// Handles failures for error mocks.
-				if _, err := prayertexter.FindIntercessors(ddbMock, "+18888888888"); err == nil {
+				if _, err := prayertexter.FindIntercessors(ctx, ddbMock, "+18888888888"); err == nil {
 					t.Fatalf("expected error, got nil")
 				}
 				testNumMethodCalls(ddbMock, txtMock, t, test)
 			} else {
 				// Handles success test cases.
-				_, err := prayertexter.FindIntercessors(ddbMock, "+18888888888")
+				_, err := prayertexter.FindIntercessors(ctx, ddbMock, "+18888888888")
 				if err != nil && !errors.Is(err, utility.ErrNoAvailableIntercessors) {
 					// NoAvailableIntercessors is an expected errors that can occur with FindIntercessors. This
 					// error should be handled accordingly by the caller. Since this is expected, it is included
@@ -2723,19 +2730,20 @@ func TestMainFlowCompletePrayer(t *testing.T) {
 	for _, test := range testCases {
 		txtMock := &mock.TextSender{}
 		ddbMock := &mock.DDBConnecter{}
+		ctx := context.Background()
 
 		t.Run(test.description, func(t *testing.T) {
 			setMocks(ddbMock, txtMock, test)
 
 			if test.expectedError {
 				// Handles failures for error mocks
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err == nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err == nil {
 					t.Fatalf("expected error, got nil")
 				}
 				testNumMethodCalls(ddbMock, txtMock, t, test)
 			} else {
 				// Handles success test cases
-				if err := prayertexter.MainFlow(test.initialMessage, ddbMock, txtMock); err != nil {
+				if err := prayertexter.MainFlow(ctx, ddbMock, txtMock, test.initialMessage); err != nil {
 					t.Fatalf("unexpected error starting MainFlow: %v", err)
 				}
 

--- a/internal/utility/aws.go
+++ b/internal/utility/aws.go
@@ -19,13 +19,11 @@ const (
 	AwsSvcMaxBackoffConfigPath = "conf.aws.backoff"
 )
 
-func GetAwsConfig() (aws.Config, error) {
+func GetAwsConfig(ctx context.Context) (aws.Config, error) {
 	maxRetry := viper.GetInt(AwsSvcRetryAttemptsConfigPath)
 	maxBackoff := viper.GetInt(AwsSvcMaxBackoffConfigPath)
 
-	cfg, err := config.LoadDefaultConfig(
-		context.TODO(),
-		config.WithRegion("us-west-1"),
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-1"),
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(o *retry.StandardOptions) {
 				o.MaxAttempts = maxRetry


### PR DESCRIPTION
I wanted to align with go and aws sdk best practices in regards to context. The lambda handler function that calls the whole application already takes a context as a parameter. This context was not being used at all. In AWS functions for dynamodb and pinpointsms, a new context was being created and provided to the aws sdk functions for external AWS calls. To improve this, I am passing down the lambda handler context to all the aws function calls. This way if the higher level context gets canceled, it will pass down to all of the aws function calls.

I also rearranged all dynamodb and sms client parameters to be at the beginning, along with some other minor changes such as changing config_test.go to use t.Setenv instead of using os.Setenv.