### PR TITLE
Implemented logging for aws sdk retries

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
         "prsn",
         "pryr",
         "queuetable",
+        "Retryable",
         "Retryer",
         "sndr",
         "sttrackr",

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Good dynamodb commands:
     - this may help with allowing for concurrent lambda functions to run
 - decide if/where to implement dynamodb strongly consistent writes (as opposed to default eventual consistency)
     - this may help with allowing for concurrent lambda functions to run
-- add logging for aws retry operations - is it worth it?
 - save all initial sign up text messages for 10-DLC number requirements
 - web frontend for sign up process
     - possibly could add other features eventually

--- a/internal/utility/aws.go
+++ b/internal/utility/aws.go
@@ -25,10 +25,11 @@ func GetAwsConfig(ctx context.Context) (aws.Config, error) {
 
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-1"),
 		config.WithRetryer(func() aws.Retryer {
-			return retry.NewStandard(func(o *retry.StandardOptions) {
+			retryer := retry.NewStandard(func(o *retry.StandardOptions) {
 				o.MaxAttempts = maxRetry
 				o.MaxBackoff = time.Duration(maxBackoff) * time.Second
 			})
+			return &LoggingRetryer{delegate: retryer}
 		}))
 
 	return cfg, WrapError(err, "failed to get aws config")

--- a/internal/utility/awsretrylogger.go
+++ b/internal/utility/awsretrylogger.go
@@ -1,0 +1,38 @@
+package utility
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+// Logging Retryer implements the aws.Retryer interface. The only purpose of this is so AWS retries are logged within
+// this application. If not for this, AWS retries would happen silently. This should improve debugging and give insight
+// into AWS retry attempts.
+type LoggingRetryer struct {
+	delegate aws.Retryer
+}
+
+func (r *LoggingRetryer) IsErrorRetryable(err error) bool {
+	return r.delegate.IsErrorRetryable(err)
+}
+
+func (r *LoggingRetryer) MaxAttempts() int {
+	return r.delegate.MaxAttempts()
+}
+
+func (r *LoggingRetryer) GetRetryToken(ctx context.Context, opErr error) (releaseToken func(error) error, err error) {
+	return r.delegate.GetRetryToken(ctx, opErr)
+}
+
+func (r *LoggingRetryer) GetInitialToken() (releaseToken func(error) error) {
+	return r.delegate.GetInitialToken()
+}
+
+func (r *LoggingRetryer) RetryDelay(attempt int, opErr error) (time.Duration, error) {
+	delay, calcErr := r.delegate.RetryDelay(attempt, opErr)
+	slog.Warn("AWS retry", "attempt", attempt, "error", opErr, "delay", delay)
+	return delay, calcErr
+}


### PR DESCRIPTION
I thought it would be a good idea to have logging within the prayertexter application when aws services were called and retried. Currently the implementation uses aws go sdk v2 to interact with all aws services (dynamodb, pinpointsms). The aws sdk has an easy way to set up retry and backoff limits in case there are transient failures. However since the sdk handles all of this for you, there is no logging within the actual application when a service call is retried. I thought it would be helpful for debugging purposes to have a log generated every time an aws service errors and has to retry. This is done by implementing the aws Retryer interface and wrapping it so that it does 1 additional logging task besides the normal tasks that the retryer already implements.