### PR TITLE
Exported aws region as a configurable option through the config package and updated readme with new todo item

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Good dynamodb commands:
 - web frontend for sign up process
     - possibly could add other features eventually
     - minimum required feature is to be able to complete entire sign up flow in a web form and submit to be added to prayer texter app
+- implement single prayer table with dynamodb sort key
+    - sort key will be whether prayer is active or queue
+    - this will allow the consolidation of 2 prayer tables into one
 - dynamodb TransactWriteItems for atomic write operations (to help with error recovery)
     - this will complicate current implementation of dynamodb because new functions and mocks will be needed
     - this will allow for better recovery because TransactWriteItems allows for grouping of multiple put/delete items into a single

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 func setDefaults() {
 	defaults := map[string]any{
 		"aws": map[string]any{
+			"region":  utility.DefaultAwsRegion,
 			"backoff": utility.DefaultAwsSvcMaxBackoff,
 			"retry":   utility.DefaultAwsSvcRetryAttempts,
 			"db": map[string]any{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,6 +16,7 @@ func TestDefaultConfigValues(t *testing.T) {
 		config.InitConfig()
 
 		configs := map[string]any{
+			utility.AwsRegionConfigPath:             utility.DefaultAwsRegion,
 			utility.AwsSvcMaxBackoffConfigPath:      utility.DefaultAwsSvcMaxBackoff,
 			utility.AwsSvcRetryAttemptsConfigPath:   utility.DefaultAwsSvcRetryAttempts,
 			db.TimeoutConfigPath:                    db.DefaultTimeout,

--- a/internal/utility/aws.go
+++ b/internal/utility/aws.go
@@ -13,6 +13,9 @@ import (
 
 // Default values for configuration that has been exposed to be used with the config package.
 const (
+	DefaultAwsRegion    = "us-west-1"
+	AwsRegionConfigPath = "conf.aws.region"
+
 	DefaultAwsSvcRetryAttempts    = 5
 	AwsSvcRetryAttemptsConfigPath = "conf.aws.retry"
 
@@ -22,10 +25,11 @@ const (
 
 // GetAwsConfig returns an aws configuration that can be used to interact with aws services.
 func GetAwsConfig(ctx context.Context) (aws.Config, error) {
+	region := viper.GetString(AwsRegionConfigPath)
 	maxRetry := viper.GetInt(AwsSvcRetryAttemptsConfigPath)
 	maxBackoff := viper.GetInt(AwsSvcMaxBackoffConfigPath)
 
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-1"),
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region),
 		config.WithRetryer(func() aws.Retryer {
 			retryer := retry.NewStandard(func(o *retry.StandardOptions) {
 				o.MaxAttempts = maxRetry

--- a/internal/utility/awsretrylogger.go
+++ b/internal/utility/awsretrylogger.go
@@ -35,8 +35,8 @@ func (r *LoggingRetryer) GetInitialToken() (releaseToken func(error) error) {
 	return r.delegate.GetInitialToken()
 }
 
-// RetryDelay delegates this to the actual aws.Retryer, while also adding additional afterwards. The purpose of this is
-// to log aws retries.
+// RetryDelay delegates to the actual aws.Retryer, while also adding logging in between so that aws retries are visible
+// in application logs.
 func (r *LoggingRetryer) RetryDelay(attempt int, opErr error) (time.Duration, error) {
 	delay, calcErr := r.delegate.RetryDelay(attempt, opErr)
 	slog.Warn("AWS retry", "attempt", attempt, "error", opErr, "delay", delay)


### PR DESCRIPTION
Made aws region configurable with viper because I forgot to export it prior. AWS region should be configurable and overwritable with env variables. I also added a todo item to combine with prayer tables into a single table. This should be possible, and there should be a new sort key added for dynamodb to allow for easy sorting and reading of all prayers that are queued.