### PR TITLE
linting issue fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -371,7 +371,9 @@ linters:
       # - "default": report only the default slog logger
       # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
       # Default: ""
-      no-global: all
+      # PRAY: removed global logger checks because global logger is fine in our simple logging use case
+      # no-global: all
+      no-global: ""
       # Enforce using methods that accept a context.
       # Values:
       # - "": disabled
@@ -435,3 +437,9 @@ linters:
           - gosec
           - noctx
           - wrapcheck
+      # PRAY: skip long lines of function declarations (long parameters)
+      - source: '^func'
+        linters: [ golines ]
+      # PRAY: skip long lines of map[string]types.AttributeValue in test files
+      - source: '&types.AttributeValueMember'
+        linters: [ golines ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
         "ldflags",
         "localdev",
         "mapstructure",
-        "mshort",
         "nolint",
         "nosec",
         "pinpointsmsvoicev",
@@ -30,5 +29,10 @@
         "testattr",
         "texter",
         "txtsvc"
+    ],
+    "cSpell.ignorePaths": [
+        ".golangci.yml",
+        "go.mod",
+        "go.sum"
     ]
 }

--- a/cmd/prayertexter/main.go
+++ b/cmd/prayertexter/main.go
@@ -52,7 +52,7 @@ func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.API
 		return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 	}
 
-	if err := prayertexter.MainFlow(ctx, ddbClnt, smsClnt, msg); err != nil {
+	if err = prayertexter.MainFlow(ctx, ddbClnt, smsClnt, msg); err != nil {
 		return events.APIGatewayProxyResponse{StatusCode: http.StatusInternalServerError}, err
 	}
 

--- a/internal/db/dynamodb.go
+++ b/internal/db/dynamodb.go
@@ -100,7 +100,7 @@ func PutDdbObject[T any](ctx context.Context, ddbClnt DDBConnecter, table string
 		return utility.WrapError(err, fmt.Sprintf("failed to marshal %T from table %s", *new(T), table))
 	}
 
-	if err := putDdbItem(ctx, ddbClnt, table, item); err != nil {
+	if err = putDdbItem(ctx, ddbClnt, table, item); err != nil {
 		return utility.WrapError(err, fmt.Sprintf("failed to put %T from table %s", *new(T), table))
 	}
 

--- a/internal/db/dynamodb_test.go
+++ b/internal/db/dynamodb_test.go
@@ -274,11 +274,11 @@ func testPutObject[T any](t *testing.T, ddbMock *mock.DDBConnecter, expectedObje
 	expectedMap := make(map[string]any)
 	lastPutMap := make(map[string]any)
 
-	if err := attributevalue.UnmarshalMap(expectedDdbItem.Output.Item, &expectedMap); err != nil {
+	if err = attributevalue.UnmarshalMap(expectedDdbItem.Output.Item, &expectedMap); err != nil {
 		t.Errorf("failed to unmarshal expectedDdbItem: %v", err)
 	}
 
-	if err := attributevalue.UnmarshalMap(lastPutItem, &lastPutMap); err != nil {
+	if err = attributevalue.UnmarshalMap(lastPutItem, &lastPutMap); err != nil {
 		t.Errorf("failed to unmarshal lastPutItem: %v", err)
 	}
 

--- a/internal/messaging/textmessage.go
+++ b/internal/messaging/textmessage.go
@@ -102,7 +102,8 @@ func SendText(ctx context.Context, smsClnt TextSender, msg TextMessage) error {
 	// However when unit testing, we can't skip this part since this is mocked and receives inputs.
 	if !utility.IsAwsLocal() {
 		timeout := viper.GetInt(TimeoutConfigPath)
-		ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 		defer cancel()
 
 		phone := viper.GetString(PhoneConfigPath)
@@ -118,7 +119,7 @@ func SendText(ctx context.Context, smsClnt TextSender, msg TextMessage) error {
 		return utility.WrapError(err, fmt.Sprintf("failed to send text message to %s", msg.Phone))
 	}
 
-	slog.Info("sent text message", "phone", msg.Phone, "body", body)
+	slog.InfoContext(ctx, "sent text message", "phone", msg.Phone, "body", body)
 	return nil
 }
 

--- a/internal/mock/dynamodb.go
+++ b/internal/mock/dynamodb.go
@@ -27,8 +27,7 @@ type DDBConnecter struct {
 	}
 }
 
-func (m *DDBConnecter) GetItem(_ context.Context, input *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (
-	*dynamodb.GetItemOutput, error) {
+func (m *DDBConnecter) GetItem(_ context.Context, input *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	m.GetItemCalls++
 	m.GetItemInputs = append(m.GetItemInputs, *input)
 
@@ -40,8 +39,7 @@ func (m *DDBConnecter) GetItem(_ context.Context, input *dynamodb.GetItemInput, 
 	return result.Output, result.Error
 }
 
-func (m *DDBConnecter) PutItem(_ context.Context, input *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (
-	*dynamodb.PutItemOutput, error) {
+func (m *DDBConnecter) PutItem(_ context.Context, input *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
 	m.PutItemCalls++
 	m.PutItemInputs = append(m.PutItemInputs, *input)
 
@@ -53,8 +51,7 @@ func (m *DDBConnecter) PutItem(_ context.Context, input *dynamodb.PutItemInput, 
 	return nil, result.Error
 }
 
-func (m *DDBConnecter) DeleteItem(_ context.Context, input *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (
-	*dynamodb.DeleteItemOutput, error) {
+func (m *DDBConnecter) DeleteItem(_ context.Context, input *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
 	m.DeleteItemCalls++
 	m.DeleteItemInputs = append(m.DeleteItemInputs, *input)
 

--- a/internal/mock/textmessage.go
+++ b/internal/mock/textmessage.go
@@ -14,10 +14,7 @@ type TextSender struct {
 	}
 }
 
-func (m *TextSender) SendTextMessage(_ context.Context,
-	params *pinpointsmsvoicev2.SendTextMessageInput, _ ...func(*pinpointsmsvoicev2.Options)) (
-	*pinpointsmsvoicev2.SendTextMessageOutput, error) { //nolint:whitespace // line too long, needed new line
-
+func (m *TextSender) SendTextMessage(_ context.Context, params *pinpointsmsvoicev2.SendTextMessageInput, _ ...func(*pinpointsmsvoicev2.Options)) (*pinpointsmsvoicev2.SendTextMessageOutput, error) {
 	m.SendTextCalls++
 	m.SendTextInputs = append(m.SendTextInputs, params)
 

--- a/internal/object/prayer.go
+++ b/internal/object/prayer.go
@@ -76,9 +76,9 @@ func GetPrayerTable(queue bool) string {
 
 	if queue {
 		return queuedPrayersTable
-	} else {
-		return activePrayersTable
 	}
+
+	return activePrayersTable
 }
 
 // IsPrayerActive reports whether a Prayer is found (active) in dynamodb.

--- a/internal/utility/awsretrylogger.go
+++ b/internal/utility/awsretrylogger.go
@@ -26,12 +26,12 @@ func (r *LoggingRetryer) MaxAttempts() int {
 }
 
 // GetRetryToken is a dummy method to satisfy the aws.Retryer interface. It delegates to the actual Retryer.
-func (r *LoggingRetryer) GetRetryToken(ctx context.Context, opErr error) (releaseToken func(error) error, err error) {
+func (r *LoggingRetryer) GetRetryToken(ctx context.Context, opErr error) (func(error) error, error) {
 	return r.delegate.GetRetryToken(ctx, opErr)
 }
 
 // GetInitialToken is a dummy method to satisfy the aws.Retryer interface. It delegates to the actual Retryer.
-func (r *LoggingRetryer) GetInitialToken() (releaseToken func(error) error) {
+func (r *LoggingRetryer) GetInitialToken() func(error) error {
 	return r.delegate.GetInitialToken()
 }
 

--- a/internal/utility/errors.go
+++ b/internal/utility/errors.go
@@ -1,6 +1,7 @@
 package utility
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 )
@@ -19,11 +20,11 @@ const (
 
 // LogAndWrapError will log, wrap, and return an error and is used for high level functions where most logging is done.
 // If the error is nil, this will return nil as well.
-func LogAndWrapError(err error, message string, attrs ...any) error {
+func LogAndWrapError(ctx context.Context, err error, message string, attrs ...any) error {
 	if err == nil {
 		return nil
 	}
-	slog.Error(message, append(attrs, "error", err)...)
+	slog.ErrorContext(ctx, message, append(attrs, "error", err)...)
 	return fmt.Errorf("%s: %w", message, err)
 }
 


### PR DESCRIPTION
I fixed all existing linting issues in golanglint-ci. I changed logging to use slog with context on all existing slog uses. I also added some golanglint-ci exclusions for function declarations as well as with lines that include &types.AttributeValueMember  which are basically only used when unit testing. I made the decision to exclude these 2 things from the golines linter which checks for lines longer than 120. I do like keeping line length down, but at the same time it makes these 2 things harder to read when they are forced to be split into 2 lines. Thus because of this, I put back all previous function declaration lines that were force split to 2 lines back to 1 single line. I think this is easier overall to read even if some of the lines are too long.
