### PR TITLE
Added word to profanity whitelist and 1 other minor change

### DIFF
--- a/deploy/prayertexter/samconfig.toml
+++ b/deploy/prayertexter/samconfig.toml
@@ -4,4 +4,4 @@ stack_name = "prayertexter"
 resolve_s3 = true
 s3_prefix = "prayertexter"
 confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
+capabilities = "CAPABILITY_IAM CAPABILITY_NAMED_IAM"

--- a/internal/messaging/textmessage.go
+++ b/internal/messaging/textmessage.go
@@ -130,7 +130,7 @@ func SendText(ctx context.Context, smsClnt TextSender, msg TextMessage) error {
 // is detected.
 func (t TextMessage) CheckProfanity() string {
 	// We need to remove some words from the profanity filter because it is too sensitive.
-	removedWords := []string{"jerk"}
+	removedWords := []string{"jerk", "ass"}
 	profanities := &goaway.DefaultProfanities
 
 	for _, word := range removedWords {


### PR DESCRIPTION
I had to whitelist "ass" from the profanity checker because it was detecting this word in this sentence:
"May she have peace as she..."
The profanity detector removes spaces and gets ass from "as she". For now I am just whitelisting this word. We can revisit later if we want more complex filtering logic.

I also added an IAM capability to the prayertexter cloudformation template because it is needed for sam deploy to work.