### PR TITLE
AWS SMS retry logic for throttle errors

### DIFF
--- a/dev/addmembers.sh
+++ b/dev/addmembers.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+payloads=(
+  '{"originationNumber":"+11111111111", "messageBody":"pray"}'
+  '{"originationNumber":"+11111111111", "messageBody":"intercessor one"}'
+  '{"originationNumber":"+11111111111", "messageBody":"2"}'
+  '{"originationNumber":"+11111111111", "messageBody":"100"}'
+
+  '{"originationNumber":"+12222222222", "messageBody":"pray"}'
+  '{"originationNumber":"+12222222222", "messageBody":"intercessor two"}'
+  '{"originationNumber":"+12222222222", "messageBody":"2"}'
+  '{"originationNumber":"+12222222222", "messageBody":"100"}'
+
+  '{"originationNumber":"+13333333333", "messageBody":"pray"}'
+  '{"originationNumber":"+13333333333", "messageBody":"intercessor three"}'
+  '{"originationNumber":"+13333333333", "messageBody":"2"}'
+  '{"originationNumber":"+13333333333", "messageBody":"100"}'
+
+  '{"originationNumber":"+14444444444", "messageBody":"pray"}'
+  '{"originationNumber":"+14444444444", "messageBody":"intercessor four"}'
+  '{"originationNumber":"+14444444444", "messageBody":"2"}'
+  '{"originationNumber":"+14444444444", "messageBody":"100"}'
+
+  '{"originationNumber":"+15555555555", "messageBody":"pray"}'
+  '{"originationNumber":"+15555555555", "messageBody":"intercessor five"}'
+  '{"originationNumber":"+15555555555", "messageBody":"2"}'
+  '{"originationNumber":"+15555555555", "messageBody":"100"}'
+
+  '{"originationNumber":"+16666666666", "messageBody":"pray"}'
+  '{"originationNumber":"+16666666666", "messageBody":"intercessor six"}'
+  '{"originationNumber":"+16666666666", "messageBody":"2"}'
+  '{"originationNumber":"+16666666666", "messageBody":"100"}'
+
+  '{"originationNumber":"+17777777777", "messageBody":"pray"}'
+  '{"originationNumber":"+17777777777", "messageBody":"intercessor seven"}'
+  '{"originationNumber":"+17777777777", "messageBody":"2"}'
+  '{"originationNumber":"+17777777777", "messageBody":"100"}'
+
+  '{"originationNumber":"+18888888888", "messageBody":"pray"}'
+  '{"originationNumber":"+18888888888", "messageBody":"intercessor eight"}'
+  '{"originationNumber":"+18888888888", "messageBody":"2"}'
+  '{"originationNumber":"+18888888888", "messageBody":"100"}'
+
+  '{"originationNumber":"+19999999999", "messageBody":"pray"}'
+  '{"originationNumber":"+19999999999", "messageBody":"intercessor nine"}'
+  '{"originationNumber":"+19999999999", "messageBody":"2"}'
+  '{"originationNumber":"+19999999999", "messageBody":"100"}'
+
+  '{"originationNumber":"+11234567890", "messageBody":"pray"}'
+  '{"originationNumber":"+11234567890", "messageBody":"normal member one"}'
+  '{"originationNumber":"+11234567890", "messageBody":"1"}'
+
+  '{"originationNumber":"+12345678901", "messageBody":"pray"}'
+  '{"originationNumber":"+12345678901", "messageBody":"normal member two"}'
+  '{"originationNumber":"+12345678901", "messageBody":"1"}'
+
+  '{"originationNumber":"+13456789012", "messageBody":"pray"}'
+  '{"originationNumber":"+13456789012", "messageBody":"normal member three"}'
+  '{"originationNumber":"+13456789012", "messageBody":"1"}'
+)
+
+for payload in "${payloads[@]}"; do
+  echo "Sending: $payload"
+  curl -s -X POST http://127.0.0.1:3000/ \
+    -H 'Content-Type: application/json' \
+    -d "$payload"
+  echo ""
+done

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.15.17
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.1
+	github.com/aws/smithy-go v1.22.2
 	github.com/spf13/viper v1.20.1
 
 )
@@ -27,7 +28,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.1 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/internal/messaging/messages.go
+++ b/internal/messaging/messages.go
@@ -1,0 +1,56 @@
+package messaging
+
+// Default values for configuration that has been exposed to be used with the config package.
+const (
+	DefaultPhonePool    = "dummy"
+	PhonePoolConfigPath = "conf.aws.sms.phonepool"
+
+	DefaultTimeout    = 60
+	TimeoutConfigPath = "conf.aws.sms.timeout"
+)
+
+// Sign up stage text message content sent by prayertexter.
+const (
+	MsgNameRequest = "Reply with your name, or 2 to stay anonymous."
+	MsgInvalidName = "Sorry, that name is not valid. Please reply with a name that is at least 2 letters long and " +
+		"only contains letters or spaces."
+	MsgMemberTypeRequest = "Reply 1 to send prayer request, or 2 to be added to the intercessors list (to pray for " +
+		"others). 2 will also allow you to send in prayer requests."
+	MsgPrayerInstructions = "You are now signed up to send prayer requests! You can text them directly to this number" +
+		" at any time."
+	MsgPrayerNumRequest = "Reply with the number of maximum prayer texts that you are willing to receive and pray for " +
+		"each week."
+	MsgIntercessorInstructions = "You are now signed up to receive prayer requests. Please try to pray for the " +
+		"requests as soon as you receive them. " + MsgPrayed
+	MsgPrayed             = "Once you have prayed, reply with the word prayed so that the prayer can be confirmed."
+	MsgWrongInput         = "Incorrect input received during sign up, please try again."
+	MsgSignUpConfirmation = "You have opted into PrayerTexter. Msg & data rates may apply."
+	MsgRemoveUser         = "You have been removed from PrayerTexter. To sign back up, text the word pray to this " +
+		"number."
+)
+
+// Prayer request stage message content sent by prayertexter.
+const (
+	MsgInvalidRequest = "Sorry, that request is not valid. Prayer requests must contain at least 5 words."
+	MsgPrayerIntro    = "Hello! Please pray for PLACEHOLDER:\n"
+	MsgPrayerQueued   = "We could not find any available intercessors. Your prayer has been added to the queue and " +
+		"will get sent out as soon as someone is available."
+	MsgPrayerAssigned = "Your prayer request has been sent out and assigned!"
+	MsgPrayerReminder = "This is a friendly reminder to pray for PLACEHOLDER:\n"
+)
+
+// Prayer completion stage message content sent by prayertexter.
+const (
+	MsgNoActivePrayer     = "You have no active prayers to mark as prayed."
+	MsgPrayerThankYou     = "Thank you for praying! We let the prayer requestor know that you have prayed for them."
+	MsgPrayerConfirmation = "You're prayer request has been prayed for by PLACEHOLDER."
+)
+
+// Other (general) message content sent by prayertexter.
+const (
+	MsgProfanityDetected = "There was profanity found in your message:\n\nPLACEHOLDER\n\nPlease try again"
+	MsgHelp              = "To receive support, please email info@4jesusministries.com or call/text (949) 313-4375. " +
+		"Thank you!"
+	MsgPre  = "PrayerTexter: "
+	MsgPost = "Reply HELP for help or STOP to cancel."
+)

--- a/internal/messaging/textmessage.go
+++ b/internal/messaging/textmessage.go
@@ -6,6 +6,7 @@ package messaging
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -14,62 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2"
 	"github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2/types"
+	"github.com/aws/smithy-go"
 	"github.com/spf13/viper"
-)
-
-// Default values for configuration that has been exposed to be used with the config package.
-const (
-	DefaultPhonePool    = "dummy"
-	PhonePoolConfigPath = "conf.aws.sms.phonepool"
-
-	DefaultTimeout    = 60
-	TimeoutConfigPath = "conf.aws.sms.timeout"
-)
-
-// Sign up stage text message content sent by prayertexter.
-const (
-	MsgNameRequest = "Reply with your name, or 2 to stay anonymous."
-	MsgInvalidName = "Sorry, that name is not valid. Please reply with a name that is at least 2 letters long and " +
-		"only contains letters or spaces."
-	MsgMemberTypeRequest = "Reply 1 to send prayer request, or 2 to be added to the intercessors list (to pray for " +
-		"others). 2 will also allow you to send in prayer requests."
-	MsgPrayerInstructions = "You are now signed up to send prayer requests! You can text them directly to this number" +
-		" at any time."
-	MsgPrayerNumRequest = "Reply with the number of maximum prayer texts that you are willing to receive and pray for " +
-		"each week."
-	MsgIntercessorInstructions = "You are now signed up to receive prayer requests. Please try to pray for the " +
-		"requests as soon as you receive them. " + MsgPrayed
-	MsgPrayed             = "Once you have prayed, reply with the word prayed so that the prayer can be confirmed."
-	MsgWrongInput         = "Incorrect input received during sign up, please try again."
-	MsgSignUpConfirmation = "You have opted into PrayerTexter. Msg & data rates may apply."
-	MsgRemoveUser         = "You have been removed from PrayerTexter. To sign back up, text the word pray to this " +
-		"number."
-)
-
-// Prayer request stage message content sent by prayertexter.
-const (
-	MsgInvalidRequest = "Sorry, that request is not valid. Prayer requests must contain at least 5 words."
-	MsgPrayerIntro    = "Hello! Please pray for PLACEHOLDER:\n"
-	MsgPrayerQueued   = "We could not find any available intercessors. Your prayer has been added to the queue and " +
-		"will get sent out as soon as someone is available."
-	MsgPrayerAssigned = "Your prayer request has been sent out and assigned!"
-	MsgPrayerReminder = "This is a friendly reminder to pray for PLACEHOLDER:\n"
-)
-
-// Prayer completion stage message content sent by prayertexter.
-const (
-	MsgNoActivePrayer     = "You have no active prayers to mark as prayed."
-	MsgPrayerThankYou     = "Thank you for praying! We let the prayer requestor know that you have prayed for them."
-	MsgPrayerConfirmation = "You're prayer request has been prayed for by PLACEHOLDER."
-)
-
-// Other (general) message content sent by prayertexter.
-const (
-	MsgProfanityDetected = "There was profanity found in your message:\n\nPLACEHOLDER\n\nPlease try again"
-	MsgHelp              = "To receive support, please email info@4jesusministries.com or call/text (949) 313-4375. " +
-		"Thank you!"
-	MsgPre  = "PrayerTexter: "
-	MsgPost = "Reply HELP for help or STOP to cancel."
 )
 
 // A TextMessage represents a received text message from a user.
@@ -103,27 +50,49 @@ func SendText(ctx context.Context, smsClnt TextSender, msg TextMessage) error {
 
 	// This helps with SAM local testing. We don't want to actually send a SMS when doing SAM local tests (for now).
 	// However when unit testing, we can't skip this part since this is mocked and receives inputs.
-	if !utility.IsAwsLocal() {
-		timeout := viper.GetInt(TimeoutConfigPath)
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
-		defer cancel()
-
-		phonepool := viper.GetString(PhonePoolConfigPath)
-		input := &pinpointsmsvoicev2.SendTextMessageInput{
-			DestinationPhoneNumber: aws.String(msg.Phone),
-			MessageBody:            aws.String(body),
-			MessageType:            types.MessageTypeTransactional,
-			OriginationIdentity:    aws.String(phonepool),
-		}
-
-		_, err := smsClnt.SendTextMessage(ctx, input)
-
-		return utility.LogAndWrapError(ctx, err, "failed to send text message", "phone", msg.Phone, "msg", msg.Body)
+	if utility.IsAwsLocal() {
+		slog.InfoContext(ctx, "sent text message (local)", "phone", msg.Phone, "body", body)
+		return nil
 	}
 
-	slog.InfoContext(ctx, "sent text message", "phone", msg.Phone, "body", body)
-	return nil
+	phonepool := viper.GetString(PhonePoolConfigPath)
+	input := &pinpointsmsvoicev2.SendTextMessageInput{
+		DestinationPhoneNumber: aws.String(msg.Phone),
+		MessageBody:            aws.String(body),
+		MessageType:            types.MessageTypeTransactional,
+		OriginationIdentity:    aws.String(phonepool),
+	}
+
+	timeoutSec := viper.GetInt(TimeoutConfigPath)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
+	defer cancel()
+
+	const maxAttempts = 3
+	const sleepDuration = 500
+	var lastErr error
+
+	// Checks if there is a ThrottlingException error and if so, perform small sleep to wait out the AWS throttle
+	// threshold limit. This happens when too many SMS messages are sent per second. AWS will throttle if we go over the
+	// specified amount which could lead to failed SMS message delivery.
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		_, err := smsClnt.SendTextMessage(ctx, input)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		var apiErr smithy.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "ThrottlingException" && attempt < maxAttempts {
+			slog.WarnContext(ctx, "throttled by Pinpoint, retrying", "attempt", attempt, "phone", msg.Phone)
+			time.Sleep(sleepDuration * time.Millisecond)
+			continue
+		}
+
+		// not retryable or out of attempts
+		break
+	}
+
+	return utility.LogAndWrapError(ctx, lastErr, "failed to send text message", "phone", msg.Phone, "msg", msg.Body)
 }
 
 // CheckProfanity returns any detected profanity found inside a string. This will return an empty string if no profanity


### PR DESCRIPTION
I implemented error retry logic for AWS SMS throttle errors only. This will retry throttle errors 3 times and sleep for 500ms in between retries. This slows down unit tests a bit but it does not feel too terrible. The hope is that in the worst case scenario, a message will be delayed by 1.5 seconds and that this would work around the AWS SMS throttle limit.

I also moved predefined message content to it's own file as well as added a test script that creates members quickly. The script can be used when doing local sam testing.