### PR TITLE
Add missing environmental variables for BlockedPhones table

### DIFF
--- a/deploy/prayertexter/template.yaml
+++ b/deploy/prayertexter/template.yaml
@@ -16,6 +16,7 @@ Globals:
       Variables:
         # Env variables need to match specific format. See prayertexter config package for details.
         PRAY_CONF_AWS_DB_PRAYER_ACTIVETABLE: !ImportValue db-ActivePrayerTableName
+        PRAY_CONF_AWS_DB_BLOCKEDPHONES_TABLE: !ImportValue db-GeneralTableName
         PRAY_CONF_AWS_DB_INTERCESSORPHONES_TABLE: !ImportValue db-GeneralTableName
         PRAY_CONF_AWS_DB_STATETRACKER_TABLE: !ImportValue db-GeneralTableName
         PRAY_CONF_AWS_DB_MEMBER_TABLE: !ImportValue db-MemberTableName

--- a/deploy/statecontroller/template.yaml
+++ b/deploy/statecontroller/template.yaml
@@ -9,6 +9,7 @@ Globals:
       Variables:
         # Env variables need to match specific format. See prayertexter config package for details.
         PRAY_CONF_AWS_DB_PRAYER_ACTIVETABLE: !ImportValue db-ActivePrayerTableName
+        PRAY_CONF_AWS_DB_BLOCKEDPHONES_TABLE: !ImportValue db-GeneralTableName
         PRAY_CONF_AWS_DB_INTERCESSORPHONES_TABLE: !ImportValue db-GeneralTableName
         PRAY_CONF_AWS_DB_STATETRACKER_TABLE: !ImportValue db-GeneralTableName
         PRAY_CONF_AWS_DB_MEMBER_TABLE: !ImportValue db-MemberTableName


### PR DESCRIPTION
I forgot to add the env variables for the BlockedPhones table in the 2 cloudformation templates. This PR adds this.